### PR TITLE
fix in PaymentPageInitializeResponse

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2302,7 +2302,7 @@ components:
           type: string
         Date:
           type: string
-          format: date
+          format: date-time
         Amount:
           $ref: '#/components/schemas/Amount'
         OrderId:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2576,7 +2576,7 @@ components:
           type: string
         Expiration:
           type: string
-          format: date
+          format: date-time
         RedirectUrl:
           type: string
       required:


### PR DESCRIPTION
not familiar in detail with openapi, 
but changing date to date-time in the field PaymentPageInitializeResponse.Expiration helps to build my client code. 
date is, as i understand it, for a regular date (day precision) - and the api returns a detailed date-time